### PR TITLE
enhancement: Change behaviour to `(String, Queue)`

### DIFF
--- a/entities/src/main/scala/com/devsisters/shardcake/Sharding.scala
+++ b/entities/src/main/scala/com/devsisters/shardcake/Sharding.scala
@@ -310,7 +310,7 @@ class Sharding private (
 
   def registerEntity[R, Req: Tag](
     entityType: EntityType[Req],
-    behavior: (String, Dequeue[Req]) => RIO[R, Nothing],
+    behavior: (String, Queue[Req]) => RIO[R, Nothing],
     terminateMessage: Promise[Nothing, Unit] => Option[Req] = (_: Promise[Nothing, Unit]) => None,
     entityMaxIdleTime: Option[Duration] = None
   ): URIO[Scope with R, Unit] = registerRecipient(entityType, behavior, terminateMessage, entityMaxIdleTime) *>
@@ -318,7 +318,7 @@ class Sharding private (
 
   def registerTopic[R, Req: Tag](
     topicType: TopicType[Req],
-    behavior: (String, Dequeue[Req]) => RIO[R, Nothing],
+    behavior: (String, Queue[Req]) => RIO[R, Nothing],
     terminateMessage: Promise[Nothing, Unit] => Option[Req] = (_: Promise[Nothing, Unit]) => None
   ): URIO[Scope with R, Unit] = registerRecipient(topicType, behavior, terminateMessage) *>
     eventsHub.publish(ShardingRegistrationEvent.TopicRegistered(topicType)).unit
@@ -328,7 +328,7 @@ class Sharding private (
 
   def registerRecipient[R, Req: Tag](
     recipientType: RecipientType[Req],
-    behavior: (String, Dequeue[Req]) => RIO[R, Nothing],
+    behavior: (String, Queue[Req]) => RIO[R, Nothing],
     terminateMessage: Promise[Nothing, Unit] => Option[Req] = (_: Promise[Nothing, Unit]) => None,
     entityMaxIdleTime: Option[Duration] = None
   ): URIO[Scope with R, Unit] =
@@ -459,7 +459,7 @@ object Sharding {
    */
   def registerEntity[R, Req: Tag](
     entityType: EntityType[Req],
-    behavior: (String, Dequeue[Req]) => RIO[R, Nothing],
+    behavior: (String, Queue[Req]) => RIO[R, Nothing],
     terminateMessage: Promise[Nothing, Unit] => Option[Req] = (_: Promise[Nothing, Unit]) => None,
     entityMaxIdleTime: Option[Duration] = None
   ): URIO[Sharding with Scope with R, Unit] =
@@ -473,7 +473,7 @@ object Sharding {
    */
   def registerTopic[R, Req: Tag](
     topicType: TopicType[Req],
-    behavior: (String, Dequeue[Req]) => RIO[R, Nothing],
+    behavior: (String, Queue[Req]) => RIO[R, Nothing],
     terminateMessage: Promise[Nothing, Unit] => Option[Req] = (_: Promise[Nothing, Unit]) => None
   ): URIO[Sharding with Scope with R, Unit] =
     ZIO.serviceWithZIO[Sharding](_.registerTopic[R, Req](topicType, behavior, terminateMessage))


### PR DESCRIPTION
Hi!

Sometimes it might make sense to send a message to the entity itself from within the handler, e.g to schedule a message to be sent that encapsulates future work that needs to be done from within a behaviour itself. The current way to do this is to call into `Sharding`, which makes the behaviours hard to mock in tests, as well as introduces unnecessary overhead.

This changes the behaviour to instead receive the full Queue (rather than the Dequeue)which makes it trivial to just publish things to oneself (which is essentially how Erlang's process model works as well :) )