### PR TITLE
Improve Streaming replies

### DIFF
--- a/entities/src/main/scala/com/devsisters/shardcake/Messenger.scala
+++ b/entities/src/main/scala/com/devsisters/shardcake/Messenger.scala
@@ -1,6 +1,7 @@
 package com.devsisters.shardcake
 
-import zio.Task
+import com.devsisters.shardcake.errors.PodUnavailable
+import zio._
 import zio.stream.ZStream
 
 /**
@@ -23,4 +24,31 @@ trait Messenger[-Msg] {
    * Send a message and receive a stream of responses of type `Res`
    */
   def sendStream[Res](entityId: String)(msg: Replier[Res] => Msg): Task[ZStream[Any, Throwable, Res]]
+
+  /**
+   * Send a message and receive a stream of responses of type `Res` and restart the stream when the remote entity is
+   * rebalanced.
+   *
+   * To do so, we need a "cursor" so the stream of responses can be restarted where it ended before the rebalance. That
+   * is, the first message sent to the remote entity contains the given initial cursor value and we extract an updated
+   * cursor from the responses so that when the remote entity is rebalanced, a new message can be sent with the last
+   * cursor we've seen in the previous stream of responses.
+   */
+  def sendStreamAutoRestart[Cursor, Res](entityId: String, cursor: Cursor)(msg: (Cursor, Replier[Res]) => Msg)(
+    updateCursor: (Cursor, Res) => Cursor
+  ): ZStream[Any, Throwable, Res] =
+    ZStream
+      .unwrap(sendStream(entityId)(msg(cursor, _)))
+      .either
+      .mapAccum(cursor) {
+        case (c, Right(res)) => updateCursor(c, res) -> Right(res)
+        case (c, Left(err))  => (c, Left(c -> err))
+      }
+      .flatMap {
+        case Right(res)                                => ZStream.succeed(res)
+        case Left((lastSeenCursor, PodUnavailable(_))) =>
+          ZStream.execute(ZIO.sleep(200.millis)) ++
+            sendStreamAutoRestart(entityId, lastSeenCursor)(msg)(updateCursor)
+        case Left((_, err))                            => ZStream.fail(err)
+      }
 }

--- a/entities/src/main/scala/com/devsisters/shardcake/Messenger.scala
+++ b/entities/src/main/scala/com/devsisters/shardcake/Messenger.scala
@@ -23,7 +23,7 @@ trait Messenger[-Msg] {
   /**
    * Send a message and receive a stream of responses of type `Res`
    */
-  def sendStream[Res](entityId: String)(msg: Replier[Res] => Msg): Task[ZStream[Any, Throwable, Res]]
+  def sendStream[Res](entityId: String)(msg: StreamReplier[Res] => Msg): Task[ZStream[Any, Throwable, Res]]
 
   /**
    * Send a message and receive a stream of responses of type `Res` and restart the stream when the remote entity is
@@ -34,7 +34,7 @@ trait Messenger[-Msg] {
    * cursor from the responses so that when the remote entity is rebalanced, a new message can be sent with the last
    * cursor we've seen in the previous stream of responses.
    */
-  def sendStreamAutoRestart[Cursor, Res](entityId: String, cursor: Cursor)(msg: (Cursor, Replier[Res]) => Msg)(
+  def sendStreamAutoRestart[Cursor, Res](entityId: String, cursor: Cursor)(msg: (Cursor, StreamReplier[Res]) => Msg)(
     updateCursor: (Cursor, Res) => Cursor
   ): ZStream[Any, Throwable, Res] =
     ZStream

--- a/entities/src/main/scala/com/devsisters/shardcake/Messenger.scala
+++ b/entities/src/main/scala/com/devsisters/shardcake/Messenger.scala
@@ -42,7 +42,7 @@ trait Messenger[-Msg] {
     updateCursor: (Cursor, Res) => Cursor
   ): ZStream[Any, Throwable, Res] =
     ZStream
-      .unwrap(sendStream(entityId)(msg(cursor, _)))
+      .unwrap(sendStream[Res](entityId)(msg(cursor, _)))
       .either
       .mapAccum(cursor) {
         case (c, Right(res)) => updateCursor(c, res) -> Right(res)

--- a/entities/src/main/scala/com/devsisters/shardcake/Replier.scala
+++ b/entities/src/main/scala/com/devsisters/shardcake/Replier.scala
@@ -1,6 +1,5 @@
 package com.devsisters.shardcake
 
-import zio.stream.ZStream
 import zio.{ URIO, ZIO }
 
 /**
@@ -9,7 +8,4 @@ import zio.{ URIO, ZIO }
 case class Replier[-R](id: String) { self =>
   def reply(reply: R): URIO[Sharding, Unit] =
     ZIO.serviceWithZIO[Sharding](_.reply(reply, self))
-
-  def replyStream(replies: ZStream[Any, Nothing, R]): URIO[Sharding, Unit] =
-    ZIO.serviceWithZIO[Sharding](_.replyStream(replies, self))
 }

--- a/entities/src/main/scala/com/devsisters/shardcake/Sharding.scala
+++ b/entities/src/main/scala/com/devsisters/shardcake/Sharding.scala
@@ -189,7 +189,7 @@ class Sharding private (
         .as(repliers - replier.id)
     )
 
-  def replyStream[Reply](replies: ZStream[Any, Nothing, Reply], replier: Replier[Reply]): UIO[Unit] =
+  def replyStream[Reply](replies: ZStream[Any, Nothing, Reply], replier: StreamReplier[Reply]): UIO[Unit] =
     replyChannels.updateZIO(repliers =>
       ZIO
         .whenCase(repliers.get(replier.id)) { case Some(q) => q.asInstanceOf[ReplyChannel[Reply]].replyStream(replies) }
@@ -275,9 +275,9 @@ class Sharding private (
             .interruptible
         }
 
-      def sendStream[Res](entityId: String)(msg: Replier[Res] => Msg): Task[ZStream[Any, Throwable, Res]] =
+      def sendStream[Res](entityId: String)(msg: StreamReplier[Res] => Msg): Task[ZStream[Any, Throwable, Res]] =
         Random.nextUUID.flatMap { uuid =>
-          sendMessageStreaming[Res](entityId, msg(Replier(uuid.toString)), Some(uuid.toString))
+          sendMessageStreaming[Res](entityId, msg(StreamReplier(uuid.toString)), Some(uuid.toString))
         }
 
       private def sendMessage[Res](entityId: String, msg: Msg, replyId: Option[String]): Task[Option[Res]] =

--- a/entities/src/main/scala/com/devsisters/shardcake/StreamReplier.scala
+++ b/entities/src/main/scala/com/devsisters/shardcake/StreamReplier.scala
@@ -1,0 +1,12 @@
+package com.devsisters.shardcake
+
+import zio.stream.ZStream
+import zio.{ URIO, ZIO }
+
+/**
+ * A metadata object that allows sending a stream of responses back to the sender
+ */
+final case class StreamReplier[-R](id: String) { self =>
+  def replyStream(replies: ZStream[Any, Nothing, R]): URIO[Sharding, Unit] =
+    ZIO.serviceWithZIO[Sharding](_.replyStream(replies, self))
+}

--- a/entities/src/test/scala/com/devsisters/shardcake/ShardingSpec.scala
+++ b/entities/src/test/scala/com/devsisters/shardcake/ShardingSpec.scala
@@ -83,10 +83,10 @@ object CounterActor {
   sealed trait CounterMessage
 
   object CounterMessage {
-    case class GetCounter(replier: Replier[Int])       extends CounterMessage
-    case object IncrementCounter                       extends CounterMessage
-    case object DecrementCounter                       extends CounterMessage
-    case class StreamingChanges(replier: Replier[Int]) extends CounterMessage
+    case class GetCounter(replier: Replier[Int])             extends CounterMessage
+    case object IncrementCounter                             extends CounterMessage
+    case object DecrementCounter                             extends CounterMessage
+    case class StreamingChanges(replier: StreamReplier[Int]) extends CounterMessage
   }
 
   object Counter extends EntityType[CounterMessage]("counter")

--- a/examples/src/main/scala/example/simple/GuildBehavior.scala
+++ b/examples/src/main/scala/example/simple/GuildBehavior.scala
@@ -1,6 +1,6 @@
 package example.simple
 
-import com.devsisters.shardcake.{ EntityType, Replier, Sharding }
+import com.devsisters.shardcake.{ EntityType, Replier, Sharding, StreamReplier }
 import zio.stream.ZStream
 import zio.{ Dequeue, RIO, Ref, ZIO }
 
@@ -13,7 +13,7 @@ object GuildBehavior {
     case class Join(userId: String, replier: Replier[Try[Set[String]]]) extends GuildMessage
     case class Timeout(replier: Replier[Try[Set[String]]])              extends GuildMessage
     case class Leave(userId: String)                                    extends GuildMessage
-    case class Stream(replier: Replier[String])                         extends GuildMessage
+    case class Stream(replier: StreamReplier[String])                   extends GuildMessage
   }
 
   object Guild extends EntityType[GuildMessage]("guild")


### PR DESCRIPTION
1. add a `Messenger.sendStreamAutoRestart` that automatically restarts the stream on rebalance
1. split `Replier` into two, the original `Replier` and a `StreamReplier` so we can't reply with a single response when a stream is expected or vise-versa
