### PR TITLE
Prevent interrupting/recreating the expiration fiber too often

### DIFF
--- a/core/src/main/scala/com/devsisters/shardcake/package.scala
+++ b/core/src/main/scala/com/devsisters/shardcake/package.scala
@@ -1,5 +1,6 @@
 package com.devsisters
 
 package object shardcake {
-  type ShardId = Int
+  type ShardId     = Int
+  type EpochMillis = Long
 }


### PR DESCRIPTION
If we have a high volume of requests per unit time coming to an single actor, we will experience performance degradation due to having to constantly interrupt and regenerate the expiration fiber. This PR avoids regenerating the fiber each time by storing when the fiber last received a message and calculating how long it should wait from that.