### PR TITLE
Catch fiber error in replyStream

### DIFF
--- a/entities/src/main/scala/com/devsisters/shardcake/internal/ReplyChannel.scala
+++ b/entities/src/main/scala/com/devsisters/shardcake/internal/ReplyChannel.scala
@@ -20,7 +20,7 @@ private[shardcake] object ReplyChannel {
     def replyStream(stream: ZStream[Any, Throwable, A]): UIO[Unit] =
       (stream
         .runForeachChunk(chunk => queue.offer(Take.chunk(chunk)))
-        .foldCause(cause => queue.offer(Take.failCause(cause)), _ => queue.offer(Take.end)) race await).fork.unit
+        .foldCauseZIO(cause => queue.offer(Take.failCause(cause)), _ => queue.offer(Take.end)) race await).fork.unit
     val output: ZStream[Any, Throwable, A]                         = ZStream.fromQueueWithShutdown(queue).flattenTake.onError(fail)
   }
 

--- a/entities/src/main/scala/com/devsisters/shardcake/internal/ReplyChannel.scala
+++ b/entities/src/main/scala/com/devsisters/shardcake/internal/ReplyChannel.scala
@@ -20,7 +20,7 @@ private[shardcake] object ReplyChannel {
     def replyStream(stream: ZStream[Any, Throwable, A]): UIO[Unit] =
       (stream
         .runForeachChunk(chunk => queue.offer(Take.chunk(chunk)))
-        .onExit(e => queue.offer(e.foldExit(Take.failCause, _ => Take.end))) race await).fork.unit
+        .foldCause(cause => queue.offer(Take.failCause(cause)), _ => queue.offer(Take.end)) race await).fork.unit
     val output: ZStream[Any, Throwable, A]                         = ZStream.fromQueueWithShutdown(queue).flattenTake.onError(fail)
   }
 


### PR DESCRIPTION
This will prevent zio to log that a fiber ended with an error.