### PR TITLE
Fix slow memory leak while an actor stays active

### DIFF
--- a/entities/src/main/scala/com/devsisters/shardcake/internal/EntityManager.scala
+++ b/entities/src/main/scala/com/devsisters/shardcake/internal/EntityManager.scala
@@ -60,7 +60,7 @@ private[shardcake] object EntityManager {
     private def startExpirationFiber(entityId: String): UIO[Fiber[Nothing, Unit]] = {
       val maxIdleTime = entityMaxIdleTime getOrElse config.entityMaxIdleTime
 
-      def sleep(duration: Duration): UIO[Any] =
+      def sleep(duration: Duration): UIO[Unit] =
         (Clock.sleep(duration) *> currentTimeInMilliseconds <*> entitiesLastReceivedAt.get).flatMap { case (cdt, map) =>
           val lastReceivedAt = map.getOrElse(entityId, 0L)
           val remaining      = maxIdleTime minus Duration.fromMillis(cdt - lastReceivedAt)


### PR DESCRIPTION
See problem described here: https://developers.portone.io/blog/posts/2024-02/v2-oom