### PR TITLE
Add the ability to set no timeout in Messenger

### DIFF
--- a/entities/src/main/scala/com/devsisters/shardcake/Messenger.scala
+++ b/entities/src/main/scala/com/devsisters/shardcake/Messenger.scala
@@ -56,3 +56,12 @@ trait Messenger[-Msg] {
         case Left((_, err))                          => ZStream.fail(err)
       }
 }
+
+object Messenger {
+  sealed trait MessengerTimeout
+  object MessengerTimeout {
+    case object NoTimeout                  extends MessengerTimeout
+    case object InheritConfigTimeout       extends MessengerTimeout
+    case class Timeout(duration: Duration) extends MessengerTimeout
+  }
+}


### PR DESCRIPTION
`timeout` introduces some overhead (race is quite slow in zio), it makes sense to allow no timeout when needed.