### PR TITLE
Add zio metrics

### DIFF
--- a/entities/src/main/scala/com/devsisters/shardcake/Metrics.scala
+++ b/entities/src/main/scala/com/devsisters/shardcake/Metrics.scala
@@ -1,0 +1,10 @@
+package com.devsisters.shardcake
+
+import zio.metrics.Metric
+import zio.metrics.Metric.Gauge
+
+object Metrics {
+  val shards: Gauge[Double]     = Metric.gauge("shardcake.shards")
+  val entities: Gauge[Double]   = Metric.gauge("shardcake.entities")
+  val singletons: Gauge[Double] = Metric.gauge("shardcake.singletons")
+}

--- a/manager/src/main/scala/com/devsisters/shardcake/ManagerMetrics.scala
+++ b/manager/src/main/scala/com/devsisters/shardcake/ManagerMetrics.scala
@@ -1,0 +1,13 @@
+package com.devsisters.shardcake
+
+import zio.metrics.Metric
+import zio.metrics.Metric.{ Counter, Gauge }
+
+object ManagerMetrics {
+  val pods: Gauge[Double]             = Metric.gauge("shardcake.pods")
+  val assignedShards: Gauge[Double]   = Metric.gauge("shardcake.shards_assigned")
+  val unassignedShards: Gauge[Double] = Metric.gauge("shardcake.shards_unassigned")
+
+  val rebalances: Counter[Long]       = Metric.counter("shardcake.rebalances")
+  val podHealthChecked: Counter[Long] = Metric.counter("shardcake.pod_health_checked")
+}


### PR DESCRIPTION
- Shard manager
  - Rebalance events (counter)
  - Pod health checked (counter with tag by pod ip)
  - Registered pods (gauge)
  - Assigned shards (gauge with tag by pod ip)
  - Unassigned shards (gauge)
- Pod
  - Number of assigned shards (gauge)
  - Number of live entities (gauge with tag by entity type)
  - Number of live singletons (gauge with tag by singleton name)