### PR TITLE
Fix unassignedShards metric and rename singletons metric tag

### DIFF
--- a/entities/src/main/scala/com/devsisters/shardcake/Sharding.scala
+++ b/entities/src/main/scala/com/devsisters/shardcake/Sharding.scala
@@ -68,7 +68,7 @@ class Sharding private (
           ZIO.foreach(singletons) {
             case (name, run, None) =>
               ZIO.logDebug(s"Starting singleton $name") *>
-                Metrics.singletons.tagged("name", name).increment *>
+                Metrics.singletons.tagged("singleton_name", name).increment *>
                 run.forkDaemon.map(fiber => (name, run, Some(fiber)))
             case other             => ZIO.succeed(other)
           }
@@ -83,7 +83,7 @@ class Sharding private (
           ZIO.foreach(singletons) {
             case (name, run, Some(fiber)) =>
               ZIO.logDebug(s"Stopping singleton $name") *>
-                Metrics.singletons.tagged("name", name).decrement *>
+                Metrics.singletons.tagged("singleton_name", name).decrement *>
                 fiber.interrupt.as((name, run, None))
             case other                    => ZIO.succeed(other)
           }

--- a/manager/src/main/scala/com/devsisters/shardcake/ShardManager.scala
+++ b/manager/src/main/scala/com/devsisters/shardcake/ShardManager.scala
@@ -77,6 +77,7 @@ class ShardManager(
                            }
           _             <- ManagerMetrics.pods.decrement
           _             <- eventsHub.publish(ShardingEvent.PodUnregistered(podAddress))
+          _             <- ManagerMetrics.unassignedShards.incrementBy(unassignments.size)
           _             <- eventsHub
                              .publish(ShardingEvent.ShardsUnassigned(podAddress, unassignments))
                              .when(unassignments.nonEmpty)

--- a/manager/src/main/scala/com/devsisters/shardcake/ShardManager.scala
+++ b/manager/src/main/scala/com/devsisters/shardcake/ShardManager.scala
@@ -76,8 +76,8 @@ class ShardManager(
                              )
                            }
           _             <- ManagerMetrics.pods.decrement
-          _             <- eventsHub.publish(ShardingEvent.PodUnregistered(podAddress))
           _             <- ManagerMetrics.unassignedShards.incrementBy(unassignments.size)
+          _             <- eventsHub.publish(ShardingEvent.PodUnregistered(podAddress))
           _             <- eventsHub
                              .publish(ShardingEvent.ShardsUnassigned(podAddress, unassignments))
                              .when(unassignments.nonEmpty)


### PR DESCRIPTION
`unassignedShards` wasn't updated on `unregister` which could cause the metric to be negative.
`name` is too generic for a tag and is used for other purpose so renamed it to `singleton_name`.