### PR TITLE
Add possibility for interceptors in the GrpcPods client

### DIFF
--- a/protocol-grpc/src/main/scala/com/devsisters/shardcake/GrpcConfig.scala
+++ b/protocol-grpc/src/main/scala/com/devsisters/shardcake/GrpcConfig.scala
@@ -1,6 +1,7 @@
 package com.devsisters.shardcake
 
 import zio._
+import scalapb.zio_grpc.ZClientInterceptor
 
 import java.util.concurrent.Executor
 
@@ -11,9 +12,14 @@ import java.util.concurrent.Executor
  * @param executor a custom executor to pass to grpc-java when creating gRPC clients and servers
  * @param shutdownTimeout the timeout to wait for the gRPC server to shutdown before forcefully shutting it down
  */
-case class GrpcConfig(maxInboundMessageSize: Int, executor: Option[Executor], shutdownTimeout: Duration)
+case class GrpcConfig(
+  maxInboundMessageSize: Int,
+  executor: Option[Executor],
+  shutdownTimeout: Duration,
+  interceptors: Seq[ZClientInterceptor]
+)
 
 object GrpcConfig {
   val default: GrpcConfig =
-    GrpcConfig(maxInboundMessageSize = 32 * 1024 * 1024, None, 3.seconds)
+    GrpcConfig(maxInboundMessageSize = 32 * 1024 * 1024, None, 3.seconds, Seq.empty)
 }

--- a/protocol-grpc/src/main/scala/com/devsisters/shardcake/GrpcConfig.scala
+++ b/protocol-grpc/src/main/scala/com/devsisters/shardcake/GrpcConfig.scala
@@ -11,6 +11,7 @@ import java.util.concurrent.Executor
  * @param maxInboundMessageSize the maximum message size allowed to be received by the grpc client
  * @param executor a custom executor to pass to grpc-java when creating gRPC clients and servers
  * @param shutdownTimeout the timeout to wait for the gRPC server to shutdown before forcefully shutting it down
+ * @param interceptors the interceptors to be used by the gRPC client, e.g for adding tracing or logging
  */
 case class GrpcConfig(
   maxInboundMessageSize: Int,

--- a/protocol-grpc/src/main/scala/com/devsisters/shardcake/GrpcPods.scala
+++ b/protocol-grpc/src/main/scala/com/devsisters/shardcake/GrpcPods.scala
@@ -41,7 +41,7 @@ class GrpcPods(
                 }
               }
 
-              val channel = ZManagedChannel(builder)
+              val channel = ZManagedChannel(builder, config.interceptors)
               // create a fiber that never ends and keeps the connection alive
               for {
                 _          <- ZIO.logDebug(s"Opening connection to pod $pod")


### PR DESCRIPTION
This will make it possible to for example add a client interceptor that handles tracing propagation between pods etc