### PR TITLE
Keep assignments got from shard manager in updateAssignments

### DIFF
--- a/entities/src/main/scala/com/devsisters/shardcake/Sharding.scala
+++ b/entities/src/main/scala/com/devsisters/shardcake/Sharding.scala
@@ -139,7 +139,7 @@ class Sharding private (
       Metrics.shards
         .set(assignmentsOpt.count { case (_, podOpt) => podOpt.contains(address) })
         .when(fromShardManager) *>
-      (if (fromShardManager) shardAssignments.update(map => if (map.isEmpty) assignments else map)
+      (if (fromShardManager) shardAssignments.set(assignments)
        else
          shardAssignments.update(map =>
            // we keep self assignments (we don't override them with the new assignments


### PR DESCRIPTION
It seems that here client will throw away assignments got from shard manager if there are any assignments already. Not sure if that was intended.