### PR TITLE
Restart `refreshAssignments` stream on failure

### DIFF
--- a/entities/src/main/scala/com/devsisters/shardcake/Sharding.scala
+++ b/entities/src/main/scala/com/devsisters/shardcake/Sharding.scala
@@ -172,7 +172,7 @@ class Sharding private (
                            }
                            .forkDaemon
                            .withFinalizer(_.interrupt)
-      _ <- latch.await
+      _               <- latch.await
     } yield ()
 
   private[shardcake] def isShuttingDown: UIO[Boolean] =

--- a/entities/src/main/scala/com/devsisters/shardcake/Sharding.scala
+++ b/entities/src/main/scala/com/devsisters/shardcake/Sharding.scala
@@ -150,7 +150,7 @@ class Sharding private (
   }
 
   private[shardcake] val refreshAssignments: ZIO[Scope, Nothing, Unit] =
-    (for {
+    for {
       latch           <- Promise.make[Nothing, Unit]
       assignmentStream = ZStream.fromZIO(
                            // first, get the assignments from the shard manager directly
@@ -163,16 +163,17 @@ class Sharding private (
                          }.runDrain
                            .retry(Schedule.fixed(config.refreshAssignmentsRetryInterval))
                            .interruptible
+                           .catchAllCause {
+                             case cause if cause.isInterrupted =>
+                               ZIO.unit
+                             case cause                        =>
+                               ZIO.logErrorCause(s"Error refreshing assignments, retrying...", cause) *>
+                                 refreshAssignments
+                           }
                            .forkDaemon
                            .withFinalizer(_.interrupt)
-      _               <- latch.await
-    } yield ()).catchAllCause {
-      case cause if cause.isInterrupted =>
-        ZIO.unit
-      case cause                        =>
-        ZIO.logErrorCause(s"Error refreshing assignments, retrying...", cause) *>
-          refreshAssignments
-    }
+      _ <- latch.await
+    } yield ()
 
   private[shardcake] def isShuttingDown: UIO[Boolean] =
     isShuttingDownRef.get

--- a/entities/src/main/scala/com/devsisters/shardcake/Sharding.scala
+++ b/entities/src/main/scala/com/devsisters/shardcake/Sharding.scala
@@ -150,7 +150,7 @@ class Sharding private (
   }
 
   private[shardcake] val refreshAssignments: ZIO[Scope, Nothing, Unit] =
-    for {
+    (for {
       latch           <- Promise.make[Nothing, Unit]
       assignmentStream = ZStream.fromZIO(
                            // first, get the assignments from the shard manager directly
@@ -166,7 +166,13 @@ class Sharding private (
                            .forkDaemon
                            .withFinalizer(_.interrupt)
       _               <- latch.await
-    } yield ()
+    } yield ()).catchAllCause {
+      case cause if cause.isInterrupted =>
+        ZIO.unit
+      case cause                        =>
+        ZIO.logErrorCause(s"Error refreshing assignments, retrying...", cause) *>
+          refreshAssignments
+    }
 
   private[shardcake] def isShuttingDown: UIO[Boolean] =
     isShuttingDownRef.get


### PR DESCRIPTION
This PR is actually based on a suspicion of mine, that the `refreshAssignments` stream may not be running on a pod when a pod experiences high load on startup. I wan't able to reproduce this locally, because my local machine is quite fast.

Because `.retry` (line 164) doesn't catch die failures, it's possible that the stream dies, so this tries to fix that by trying to start from the beginning.

On interrupt there is no change in behavior.