### PR TITLE
Change behavior of simulateRemotePods to use the Pods API

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ val sttpVersion           = "3.9.6"
 val calibanVersion        = "2.8.1"
 val redis4catsVersion     = "1.5.2"
 val redissonVersion       = "3.27.1"
-val scalaKryoVersion      = "1.0.2"
+val scalaKryoVersion      = "1.2.0"
 val testContainersVersion = "0.41.3"
 val scalaCompatVersion    = "2.12.0"
 
@@ -212,6 +212,13 @@ lazy val commonSettings = Def.settings(
       "com.dimafeng" %% "testcontainers-scala-core" % testContainersVersion % Test
     ),
   Test / fork    := true,
+  Test / javaOptions ++= Seq(
+    // Kryo requires this with the recent versions of Java
+    "--add-opens=java.base/java.util=ALL-UNNAMED",
+    "--add-opens=java.base/java.lang=ALL-UNNAMED",
+    "--add-opens=java.base/java.lang.invoke=ALL-UNNAMED",
+    "--add-opens=java.sql/java.sql=ALL-UNNAMED"
+  ),
   scalacOptions ++= Seq(
     "-deprecation",
     "-encoding",

--- a/entities/src/test/scala/com/devsisters/shardcake/BroadcastingSpec.scala
+++ b/entities/src/test/scala/com/devsisters/shardcake/BroadcastingSpec.scala
@@ -9,11 +9,7 @@ import scala.util.Success
 
 object BroadcastingSpec extends ZIOSpecDefault {
 
-  private val config = ZLayer.succeed(
-    Config.default.copy(
-      simulateRemotePods = true
-    )
-  )
+  private val config = ZLayer.succeed(Config.default)
 
   def spec: Spec[TestEnvironment with Scope, Any] =
     suite("BroadcastingSpec")(

--- a/storage-redis/src/main/scala/com/devsisters/shardcake/StorageRedis.scala
+++ b/storage-redis/src/main/scala/com/devsisters/shardcake/StorageRedis.scala
@@ -52,7 +52,10 @@ object StorageRedis {
 
         def savePods(pods: Map[PodAddress, Pod]): Task[Unit] =
           stringClient.del(config.podsKey) *>
-            stringClient.hSet(config.podsKey, pods.map { case (k, v) => k.toString -> v.version }).unit
+            stringClient
+              .hSet(config.podsKey, pods.map { case (k, v) => k.toString -> v.version })
+              .when(pods.nonEmpty)
+              .unit
       }
     }
 }


### PR DESCRIPTION
Existing option `simulateRemotePods` was only forcing serialization of sent messages but not responses. Instead, it is now using the actual `Pods` API when sending to a local shard which means it's going to go through the whole transport.