### PR TITLE
Expose current pod assignments

### DIFF
--- a/entities/src/main/scala/com/devsisters/shardcake/Sharding.scala
+++ b/entities/src/main/scala/com/devsisters/shardcake/Sharding.scala
@@ -629,6 +629,12 @@ object Sharding {
     Sharding.register.withFinalizer(_ => Sharding.unregister)
 
   /**
+   * Returns true if current node contains the singletons
+   */
+  def isSingletonNode: RIO[Sharding, Boolean] =
+    ZIO.serviceWithZIO[Sharding](_.isSingletonNode)
+
+  /**
    * Start a computation that is guaranteed to run only on a single pod.
    * Each pod should call `registerSingleton` but only a single pod will actually run it at any given time.
    */
@@ -681,6 +687,20 @@ object Sharding {
     sendTimeout: MessengerTimeout = MessengerTimeout.InheritConfigTimeout
   ): URIO[Sharding, Broadcaster[Msg]] =
     ZIO.serviceWith[Sharding](_.broadcaster(topicType, sendTimeout))
+
+  /**
+   * Get the list of shards and the pod that holds them.
+   *
+   * Note: ShardId may not show up if the shard is not assigned to any pod.
+   */
+  def getAssignments: RIO[Sharding, Map[ShardId, PodAddress]] =
+    ZIO.serviceWithZIO[Sharding](_.getAssignments)
+
+  /**
+   * Get the list of shards currently assigned to the current pod
+   */
+  def thisPodAssignments: RIO[Sharding, Chunk[ShardId]] =
+    ZIO.serviceWithZIO[Sharding](_.thisPodAssignments)
 
   /**
    * Get the list of pods currently registered to the Shard Manager

--- a/entities/src/main/scala/com/devsisters/shardcake/Sharding.scala
+++ b/entities/src/main/scala/com/devsisters/shardcake/Sharding.scala
@@ -131,7 +131,9 @@ class Sharding private (
     shardAssignments.get
 
   val thisPodAssignments: UIO[Chunk[ShardId]] =
-    getAssignments.map(_.view.collect { case (shardId, addr) if addr == this.address => shardId }.to(Chunk))
+    getAssignments.map(a =>
+      Chunk.fromIterable(a.view.collect { case (shardId, addr) if addr == this.address => shardId })
+    )
 
   val getPods: UIO[Set[PodAddress]] =
     shardAssignments.get.map(_.values.toSet)

--- a/entities/src/main/scala/com/devsisters/shardcake/Sharding.scala
+++ b/entities/src/main/scala/com/devsisters/shardcake/Sharding.scala
@@ -57,7 +57,7 @@ class Sharding private (
           shardManager.unregister(address).catchAllCause(ZIO.logErrorCause("Error during unregister", _))
     )
 
-  private def isSingletonNode: UIO[Boolean] =
+  val isSingletonNode: UIO[Boolean] =
     // Start singletons on the pod hosting shard 1.
     shardAssignments.get.map(_.get(1).contains(address))
 
@@ -127,7 +127,13 @@ class Sharding private (
       pod     = shards.get(shardId)
     } yield pod.contains(address)
 
-  def getPods: UIO[Set[PodAddress]] =
+  val getAssignments: UIO[Map[ShardId, PodAddress]] =
+    shardAssignments.get
+
+  val thisPodAssignments: UIO[Chunk[ShardId]] =
+    getAssignments.map(_.view.collect { case (shardId, addr) if addr == this.address => shardId }.to(Chunk))
+
+  val getPods: UIO[Set[PodAddress]] =
     shardAssignments.get.map(_.values.toSet)
 
   private def updateAssignments(


### PR DESCRIPTION
As discussed here: https://discord.com/channels/629491597070827530/1017210544295522325/1282152828911091793

Exposing the list of assignments helps with some kinds of optimizations, like when creating entities: the business logic can use the information to pick an entity id which has a local shard id. This saves round trip when `simulateRemotePods=false`.

This information is already visible with the storage api, although inefficient.

I've also made some frequently used ZIO values into `val`. 