### PR TITLE
Keep the shard ids sorted for logging and api

### DIFF
--- a/core/src/main/scala/com/devsisters/shardcake/package.scala
+++ b/core/src/main/scala/com/devsisters/shardcake/package.scala
@@ -1,6 +1,14 @@
 package com.devsisters
 
+import scala.collection.mutable
+
 package object shardcake {
   type ShardId     = Int
   type EpochMillis = Long
+
+  private[shardcake] def renderShardIds(ids: Iterable[ShardId]): String =
+    ids
+      .foldLeft(mutable.BitSet.empty)(_ += _)
+      .mkString("[", ", ", "]")
+
 }

--- a/entities/src/main/scala/com/devsisters/shardcake/Sharding.scala
+++ b/entities/src/main/scala/com/devsisters/shardcake/Sharding.scala
@@ -102,7 +102,7 @@ class Sharding private (
         shardAssignments.update(shards.foldLeft(_) { case (map, shard) => map.updated(shard, address) }) *>
           Metrics.shards.incrementBy(shards.size) *>
           startSingletonsIfNeeded *>
-          ZIO.logDebug(s"Assigned shards: ${shards.toArray.sortInPlace.mkString("[", ", ", "]")}")
+          ZIO.logDebug(s"Assigned shards: ${renderShardIds(shards)}")
       }
       .unit
 
@@ -110,7 +110,7 @@ class Sharding private (
     shardAssignments.update(shards.foldLeft(_) { case (map, shard) =>
       if (map.get(shard).contains(address)) map - shard else map
     }) *>
-      ZIO.logDebug(s"Unassigning shards: ${shards.toArray.sortInPlace.mkString("[", ", ", "]")}") *>
+      ZIO.logDebug(s"Unassigning shards: ${renderShardIds(shards)}") *>
       entityStates.get.flatMap(state =>
         ZIO.foreachDiscard(state.values)(
           _.entityManager.terminateEntitiesOnShards(shards) // this will return once all shards are terminated
@@ -118,7 +118,7 @@ class Sharding private (
       ) *>
       Metrics.shards.decrementBy(shards.size) *>
       stopSingletonsIfNeeded *>
-      ZIO.logDebug(s"Unassigned shards: ${shards.toArray.sortInPlace.mkString("[", ", ", "]")}")
+      ZIO.logDebug(s"Unassigned shards: ${renderShardIds(shards)}")
 
   private[shardcake] def isEntityOnLocalShards(recipientType: RecipientType[_], entityId: String): UIO[Boolean] =
     for {

--- a/entities/src/main/scala/com/devsisters/shardcake/Sharding.scala
+++ b/entities/src/main/scala/com/devsisters/shardcake/Sharding.scala
@@ -102,7 +102,7 @@ class Sharding private (
         shardAssignments.update(shards.foldLeft(_) { case (map, shard) => map.updated(shard, address) }) *>
           Metrics.shards.incrementBy(shards.size) *>
           startSingletonsIfNeeded *>
-          ZIO.logDebug(s"Assigned shards: $shards")
+          ZIO.logDebug(s"Assigned shards: ${shards.toArray.sortInPlace.mkString("[", ", ", "]")}")
       }
       .unit
 
@@ -110,7 +110,7 @@ class Sharding private (
     shardAssignments.update(shards.foldLeft(_) { case (map, shard) =>
       if (map.get(shard).contains(address)) map - shard else map
     }) *>
-      ZIO.logDebug(s"Unassigning shards: $shards") *>
+      ZIO.logDebug(s"Unassigning shards: ${shards.toArray.sortInPlace.mkString("[", ", ", "]")}") *>
       entityStates.get.flatMap(state =>
         ZIO.foreachDiscard(state.values)(
           _.entityManager.terminateEntitiesOnShards(shards) // this will return once all shards are terminated
@@ -118,7 +118,7 @@ class Sharding private (
       ) *>
       Metrics.shards.decrementBy(shards.size) *>
       stopSingletonsIfNeeded *>
-      ZIO.logDebug(s"Unassigned shards: $shards")
+      ZIO.logDebug(s"Unassigned shards: ${shards.toArray.sortInPlace.mkString("[", ", ", "]")}")
 
   private[shardcake] def isEntityOnLocalShards(recipientType: RecipientType[_], entityId: String): UIO[Boolean] =
     for {

--- a/manager/src/main/scala/com/devsisters/shardcake/GraphQLApi.scala
+++ b/manager/src/main/scala/com/devsisters/shardcake/GraphQLApi.scala
@@ -24,9 +24,11 @@ object GraphQLApi extends GenericSchema[ShardManager] {
   val api: GraphQL[ShardManager] =
     graphQL[ShardManager, Queries, Mutations, Subscriptions](
       RootResolver(
-        Queries(ZIO.serviceWithZIO(_.getAssignments.map(_.map { case (k, v) =>
-          Assignment(k, v)
-        }.toList.sortBy(_.shardId)))),
+        Queries(
+          ZIO.serviceWithZIO(
+            _.getAssignments.map(_.map { case (k, v) => Assignment(k, v) }.toList.sortBy(_.shardId))
+          )
+        ),
         Mutations(
           pod => ZIO.serviceWithZIO(_.register(pod)),
           pod => ZIO.serviceWithZIO(_.unregister(pod.address)),

--- a/manager/src/main/scala/com/devsisters/shardcake/GraphQLApi.scala
+++ b/manager/src/main/scala/com/devsisters/shardcake/GraphQLApi.scala
@@ -24,7 +24,7 @@ object GraphQLApi extends GenericSchema[ShardManager] {
   val api: GraphQL[ShardManager] =
     graphQL[ShardManager, Queries, Mutations, Subscriptions](
       RootResolver(
-        Queries(ZIO.serviceWithZIO(_.getAssignments.map(_.map { case (k, v) => Assignment(k, v) }.toList))),
+        Queries(ZIO.serviceWithZIO(_.getAssignments.map(_.map { case (k, v) => Assignment(k, v) }.toList.sortBy(_.shardId)))),
         Mutations(
           pod => ZIO.serviceWithZIO(_.register(pod)),
           pod => ZIO.serviceWithZIO(_.unregister(pod.address)),

--- a/manager/src/main/scala/com/devsisters/shardcake/GraphQLApi.scala
+++ b/manager/src/main/scala/com/devsisters/shardcake/GraphQLApi.scala
@@ -24,7 +24,9 @@ object GraphQLApi extends GenericSchema[ShardManager] {
   val api: GraphQL[ShardManager] =
     graphQL[ShardManager, Queries, Mutations, Subscriptions](
       RootResolver(
-        Queries(ZIO.serviceWithZIO(_.getAssignments.map(_.map { case (k, v) => Assignment(k, v) }.toList.sortBy(_.shardId)))),
+        Queries(ZIO.serviceWithZIO(_.getAssignments.map(_.map { case (k, v) =>
+          Assignment(k, v)
+        }.toList.sortBy(_.shardId)))),
         Mutations(
           pod => ZIO.serviceWithZIO(_.register(pod)),
           pod => ZIO.serviceWithZIO(_.unregister(pod.address)),

--- a/manager/src/main/scala/com/devsisters/shardcake/ShardManager.scala
+++ b/manager/src/main/scala/com/devsisters/shardcake/ShardManager.scala
@@ -318,10 +318,10 @@ object ShardManager {
   sealed trait ShardingEvent
   object ShardingEvent {
     case class ShardsAssigned(pod: PodAddress, shards: Set[ShardId])   extends ShardingEvent {
-      override def toString: String = s"ShardsAssigned(pod=$pod, shards=${shards.toArray.sortInPlace.mkString("[", ", ", "]")})"
+      override def toString: String = s"ShardsAssigned(pod=$pod, shards=${renderShardIds(shards)})"
     }
     case class ShardsUnassigned(pod: PodAddress, shards: Set[ShardId]) extends ShardingEvent {
-      override def toString: String = s"ShardsUnassigned(pod=$pod, shards=${shards.toArray.sortInPlace.mkString("[", ", ", "]")})"
+      override def toString: String = s"ShardsUnassigned(pod=$pod, shards=${renderShardIds(shards)})"
     }
     case class PodRegistered(pod: PodAddress)                          extends ShardingEvent
     case class PodUnregistered(pod: PodAddress)                        extends ShardingEvent

--- a/manager/src/main/scala/com/devsisters/shardcake/ShardManager.scala
+++ b/manager/src/main/scala/com/devsisters/shardcake/ShardManager.scala
@@ -10,7 +10,7 @@ import zio.stream.ZStream
 
 import scala.annotation.tailrec
 import scala.collection.compat._
-import scala.collection.immutable.SortedMap
+import scala.collection.immutable.{ BitSet, SortedMap }
 
 /**
  * A component in charge of assigning and unassigning shards to/from pods
@@ -68,7 +68,7 @@ class ShardManager(
           _             <- ZIO.logInfo(s"Unregistering $podAddress")
           unassignments <- stateRef.modify { state =>
                              (
-                               state.shards.collect { case (shard, Some(p)) if p == podAddress => shard }.toSet,
+                               state.shards.collect { case (shard, Some(p)) if p == podAddress => shard }.to(BitSet),
                                state.copy(
                                  pods = state.pods - podAddress,
                                  shards =
@@ -399,8 +399,8 @@ object ShardManager {
         }
     }
     val unassignments       = assignments.flatMap { case (shard, _) => state.shards.get(shard).flatten.map(shard -> _) }
-    val assignmentsPerPod   = assignments.groupBy(_._2).map { case (k, v) => k -> v.map(_._1).toSet }
-    val unassignmentsPerPod = unassignments.groupBy(_._2).map { case (k, v) => k -> v.map(_._1).toSet }
+    val assignmentsPerPod   = assignments.groupBy(_._2).map { case (k, v) => k -> v.map(_._1).to(BitSet) }
+    val unassignmentsPerPod = unassignments.groupBy(_._2).map { case (k, v) => k -> v.map(_._1).to(BitSet) }
     (assignmentsPerPod, unassignmentsPerPod)
   }
 

--- a/manager/src/main/scala/com/devsisters/shardcake/ShardManager.scala
+++ b/manager/src/main/scala/com/devsisters/shardcake/ShardManager.scala
@@ -10,6 +10,7 @@ import zio.stream.ZStream
 
 import scala.annotation.tailrec
 import scala.collection.compat._
+import scala.collection.immutable.SortedMap
 
 /**
  * A component in charge of assigning and unassigning shards to/from pods
@@ -228,7 +229,7 @@ object ShardManager {
         cdt                          <- ZIO.succeed(OffsetDateTime.now())
         initialState                  = ShardManagerState(
                                           filteredPods.map { case (k, v) => k -> PodWithMetadata(v, cdt) },
-                                          (1 to config.numberOfShards).map(_ -> None).toMap ++ filteredAssignments
+                                          (1 to config.numberOfShards).map(_ -> None).to(SortedMap) ++ filteredAssignments
                                         )
         _                            <-
           ZIO.logInfo(

--- a/manager/src/main/scala/com/devsisters/shardcake/ShardManager.scala
+++ b/manager/src/main/scala/com/devsisters/shardcake/ShardManager.scala
@@ -304,7 +304,7 @@ object ShardManager {
     if (xs eq ys) 0 else loop(xs, ys)
   }
 
-  case class ShardManagerState(pods: Map[PodAddress, PodWithMetadata], shards: Map[ShardId, Option[PodAddress]]) {
+  case class ShardManagerState(pods: Map[PodAddress, PodWithMetadata], shards: SortedMap[ShardId, Option[PodAddress]]) {
     lazy val unassignedShards: Set[ShardId]              = shards.collect { case (k, None) => k }.toSet
     lazy val averageShardsPerPod: ShardId                = if (pods.nonEmpty) shards.size / pods.size else 0
     private lazy val podVersions                         = pods.values.toList.map(extractVersion)

--- a/protocol-grpc/src/main/scala/com/devsisters/shardcake/GrpcShardingService.scala
+++ b/protocol-grpc/src/main/scala/com/devsisters/shardcake/GrpcShardingService.scala
@@ -12,14 +12,13 @@ import zio.stream.ZStream
 import zio.{ Config => _, _ }
 
 import java.util.concurrent.TimeUnit
-import scala.collection.immutable.BitSet
 
 abstract class GrpcShardingService(sharding: Sharding, timeout: Duration) extends ShardingService {
   def assignShards(request: AssignShardsRequest): ZIO[Any, StatusException, AssignShardsResponse] =
-    sharding.assign(request.shards.to(BitSet)).as(AssignShardsResponse())
+    sharding.assign(request.shards.toSet).as(AssignShardsResponse())
 
   def unassignShards(request: UnassignShardsRequest): ZIO[Any, StatusException, UnassignShardsResponse] =
-    sharding.unassign(request.shards.to(BitSet)).as(UnassignShardsResponse())
+    sharding.unassign(request.shards.toSet).as(UnassignShardsResponse())
 
   def send(request: SendRequest): ZIO[Any, StatusException, SendResponse] =
     sharding

--- a/protocol-grpc/src/main/scala/com/devsisters/shardcake/GrpcShardingService.scala
+++ b/protocol-grpc/src/main/scala/com/devsisters/shardcake/GrpcShardingService.scala
@@ -12,13 +12,14 @@ import zio.stream.ZStream
 import zio.{ Config => _, _ }
 
 import java.util.concurrent.TimeUnit
+import scala.collection.immutable.BitSet
 
 abstract class GrpcShardingService(sharding: Sharding, timeout: Duration) extends ShardingService {
   def assignShards(request: AssignShardsRequest): ZIO[Any, StatusException, AssignShardsResponse] =
-    sharding.assign(request.shards.toSet).as(AssignShardsResponse())
+    sharding.assign(request.shards.to(BitSet)).as(AssignShardsResponse())
 
   def unassignShards(request: UnassignShardsRequest): ZIO[Any, StatusException, UnassignShardsResponse] =
-    sharding.unassign(request.shards.toSet).as(UnassignShardsResponse())
+    sharding.unassign(request.shards.to(BitSet)).as(UnassignShardsResponse())
 
   def send(request: SendRequest): ZIO[Any, StatusException, SendResponse] =
     sharding


### PR DESCRIPTION
I've raised this here: https://discord.com/channels/629491597070827530/1017210544295522325/1296047667797037077

Having the assignments sorted on API and logs will help greatly for debugging. I was originally thinking of updating the internal data types to use sorted ones, but gave up (it changes too much internal structure).