### PR TITLE
Terminate all entities of each entity type in parallel

### DIFF
--- a/entities/src/main/scala/com/devsisters/shardcake/Sharding.scala
+++ b/entities/src/main/scala/com/devsisters/shardcake/Sharding.scala
@@ -47,7 +47,7 @@ class Sharding private (
         ZIO.logDebug(s"Stopping local entities") *>
           isShuttingDownRef.set(true) *>
           entityStates.get.flatMap(
-            ZIO.foreachDiscard(_) { case (name, entity) =>
+            ZIO.foreachParDiscard(_) { case (name, entity) =>
               entity.entityManager.terminateAllEntities.forkDaemon // run in a daemon fiber to make sure it doesn't get interrupted
                 .flatMap(_.join)
                 .catchAllCause(ZIO.logErrorCause(s"Error during stop of entity $name", _))


### PR DESCRIPTION
No need to do it sequentially.