### PR TITLE
Return an explicit error if getShardId is out of bounds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ package-lock.json
 node_modules/
 .DS_Store
 vuepress/docs/.vuepress/dist
+project/project/metals.sbt
+project/project/project/metals.sbt

--- a/entities/src/main/scala/com/devsisters/shardcake/Sharding.scala
+++ b/entities/src/main/scala/com/devsisters/shardcake/Sharding.scala
@@ -2,7 +2,7 @@ package com.devsisters.shardcake
 
 import com.devsisters.shardcake.Messenger.MessengerTimeout
 import com.devsisters.shardcake.Sharding.{ EntityState, ShardingRegistrationEvent }
-import com.devsisters.shardcake.errors.{ EntityNotManagedByThisPod, PodUnavailable, SendTimeoutException }
+import com.devsisters.shardcake.errors._
 import com.devsisters.shardcake.interfaces.Pods.BinaryMessage
 import com.devsisters.shardcake.interfaces.{ Pods, Serialization, Storage }
 import com.devsisters.shardcake.internal.{ EntityManager, ReplyChannel, SendChannel }
@@ -11,7 +11,6 @@ import zio.stream.ZStream
 
 import java.time.OffsetDateTime
 import scala.util.Try
-import com.devsisters.shardcake.errors.InvalidShardId
 
 /**
  * A component that takes care of communicating with sharded entities.

--- a/entities/src/main/scala/com/devsisters/shardcake/Sharding.scala
+++ b/entities/src/main/scala/com/devsisters/shardcake/Sharding.scala
@@ -11,6 +11,7 @@ import zio.stream.ZStream
 
 import java.time.OffsetDateTime
 import scala.util.Try
+import com.devsisters.shardcake.errors.InvalidShardId
 
 /**
  * A component that takes care of communicating with sharded entities.
@@ -406,7 +407,8 @@ class Sharding private (
                       }
           } yield ()
 
-        trySend
+        if (shardId > 0 && shardId <= config.numberOfShards) trySend
+        else ZIO.fail(InvalidShardId(shardId))
       }
 
       private def sendStreamGeneric[Res](
@@ -438,7 +440,8 @@ class Sharding private (
                       }
           } yield ()
 
-        trySend
+        if (shardId > 0 && shardId <= config.numberOfShards) trySend
+        else ZIO.fail(InvalidShardId(shardId))
       }
     }
 

--- a/entities/src/main/scala/com/devsisters/shardcake/Sharding.scala
+++ b/entities/src/main/scala/com/devsisters/shardcake/Sharding.scala
@@ -407,7 +407,7 @@ class Sharding private (
           } yield ()
 
         if (shardId > 0 && shardId <= config.numberOfShards) trySend
-        else ZIO.fail(InvalidShardId(shardId))
+        else ZIO.fail(InvalidShardId(entityId, shardId))
       }
 
       private def sendStreamGeneric[Res](
@@ -440,7 +440,7 @@ class Sharding private (
           } yield ()
 
         if (shardId > 0 && shardId <= config.numberOfShards) trySend
-        else ZIO.fail(InvalidShardId(shardId))
+        else ZIO.fail(InvalidShardId(entityId, shardId))
       }
     }
 

--- a/entities/src/main/scala/com/devsisters/shardcake/Sharding.scala
+++ b/entities/src/main/scala/com/devsisters/shardcake/Sharding.scala
@@ -406,7 +406,7 @@ class Sharding private (
                       }
           } yield ()
 
-        if (shardId > 0 && shardId <= config.numberOfShards) trySend
+        if (shardId >= 1 && shardId <= config.numberOfShards) trySend
         else ZIO.fail(InvalidShardId(entityId, shardId))
       }
 
@@ -439,7 +439,7 @@ class Sharding private (
                       }
           } yield ()
 
-        if (shardId > 0 && shardId <= config.numberOfShards) trySend
+        if (shardId >= 1 && shardId <= config.numberOfShards) trySend
         else ZIO.fail(InvalidShardId(entityId, shardId))
       }
     }

--- a/entities/src/main/scala/com/devsisters/shardcake/errors/InvalidShardId.scala
+++ b/entities/src/main/scala/com/devsisters/shardcake/errors/InvalidShardId.scala
@@ -1,0 +1,6 @@
+package com.devsisters.shardcake.errors
+
+/**
+ * Exception indicating that a shard id is invalid.
+ */
+case class InvalidShardId(shardId: Int) extends Exception(s"Invalid shard id: $shardId")

--- a/entities/src/main/scala/com/devsisters/shardcake/errors/InvalidShardId.scala
+++ b/entities/src/main/scala/com/devsisters/shardcake/errors/InvalidShardId.scala
@@ -3,4 +3,5 @@ package com.devsisters.shardcake.errors
 /**
  * Exception indicating that a shard id is invalid.
  */
-case class InvalidShardId(shardId: Int) extends Exception(s"Invalid shard id: $shardId")
+case class InvalidShardId(entityId: String, shardId: Int)
+    extends Exception(s"Invalid shard id: $shardId for entity $entityId")


### PR DESCRIPTION
Previously you would just get a send timeout.

Specially for @yoohaemin who made `getShardId` return 0 😄 