### PR TITLE
Make terminateAllEntities interruptible so that time out works well

### DIFF
--- a/entities/src/main/scala/com/devsisters/shardcake/Sharding.scala
+++ b/entities/src/main/scala/com/devsisters/shardcake/Sharding.scala
@@ -47,7 +47,7 @@ class Sharding private (
         isShuttingDownRef.set(true) *>
         entityStates.get.flatMap(
           ZIO.foreachParDiscard(_) { case (name, entity) =>
-            entity.entityManager.terminateAllEntities.forkDaemon // run in a daemon fiber to make sure it doesn't get interrupted
+            entity.entityManager.terminateAllEntities.interruptible.forkDaemon // run in a daemon fiber to make sure it doesn't get interrupted
               .flatMap(_.join)
               .catchAllCause(ZIO.logErrorCause(s"Error during stop of entity $name", _))
           }


### PR DESCRIPTION
When `unregister` is called inside a finalizer (for example when using `Sharding.registerScoped`), it is uninterruptible. Because of that, the timeout inside `terminateAllEntities` fails to interrupt the fiber. 