### PR TITLE
Adding a method to get the pod address for an entity.

### DIFF
--- a/entities/src/main/scala/com/devsisters/shardcake/Sharding.scala
+++ b/entities/src/main/scala/com/devsisters/shardcake/Sharding.scala
@@ -120,12 +120,15 @@ class Sharding private (
       stopSingletonsIfNeeded *>
       ZIO.logDebug(s"Unassigned shards: ${renderShardIds(shards)}")
 
-  private[shardcake] def isEntityOnLocalShards(recipientType: RecipientType[_], entityId: String): UIO[Boolean] =
+  def getPodAddress(recipientType: RecipientType[_], entityId: String): UIO[Option[PodAddress]] =
     for {
       shards <- shardAssignments.get
       shardId = getShardId(recipientType, entityId)
       pod     = shards.get(shardId)
-    } yield pod.contains(address)
+    } yield pod
+
+  def isEntityOnLocalShards(recipientType: RecipientType[_], entityId: String): UIO[Boolean] =
+    getPodAddress(recipientType, entityId).map(pod => pod.contains(address))
 
   val getAssignments: UIO[Map[ShardId, PodAddress]] =
     shardAssignments.get


### PR DESCRIPTION
This PR for https://github.com/devsisters/shardcake/issues/163. It adds a new method to get the `PodAddress` for an a given entity. It also makes the `isEntityOnLocalShards` method public.