### PR TITLE
Broken recruiting link in docs “About” section (Shardcake)

### DIFF
--- a/vuepress/docs/about/README.md
+++ b/vuepress/docs/about/README.md
@@ -3,7 +3,7 @@
 **Shardcake** is a project developed at [**Devsisters**](https://www.devsisters.com) by the team behind the popular game [**Cookie Run: Kingdom**](https://www.cookierun-kingdom.com). 
 We have been successfully using this project in production since March 2022.
 
-If you happen to be in South Korea, we are [recruiting](https://careers.devsisters.com/position/detail/?jobPosition=19)!
+If you happen to be in South Korea, we are [recruiting](https://careers.devsisters.com/ko/position?occupations=%EA%B0%9C%EB%B0%9C)!
 
 **Shardcake** was developed after years of experience with [**Akka Cluster Sharding**](https://doc.akka.io/docs/akka/current/typed/cluster-sharding.html).
 Even though code has nothing in common with Akka, credits go to them for some ideas and concepts.


### PR DESCRIPTION
The recruiting website URL has update.

Please refer to the relevant issue for more details.

#175

Good luck and thank you