### PR TITLE
Add a filter method that allows not starting the entity for some messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ vuepress/docs/.vuepress/dist
 project/project/metals.sbt
 project/project/project/metals.sbt
 .cursor
+.claude

--- a/entities/src/main/scala/com/devsisters/shardcake/Sharding.scala
+++ b/entities/src/main/scala/com/devsisters/shardcake/Sharding.scala
@@ -506,15 +506,18 @@ class Sharding private (
     entityType: EntityType[Req],
     behavior: (String, Queue[Req]) => RIO[R, Nothing],
     terminateMessage: Promise[Nothing, Unit] => Option[Req] = (_: Promise[Nothing, Unit]) => None,
-    entityMaxIdleTime: Option[Duration] = None
-  ): URIO[Scope with R, Unit] = registerRecipient(entityType, behavior, terminateMessage, entityMaxIdleTime) *>
-    eventsHub.publish(ShardingRegistrationEvent.EntityRegistered(entityType)).unit
+    entityMaxIdleTime: Option[Duration] = None,
+    loadEntity: Req => Boolean = (_: Req) => true
+  ): URIO[Scope with R, Unit] =
+    registerRecipient(entityType, behavior, terminateMessage, entityMaxIdleTime, loadEntity) *>
+      eventsHub.publish(ShardingRegistrationEvent.EntityRegistered(entityType)).unit
 
   def registerTopic[R, Req: Tag](
     topicType: TopicType[Req],
     behavior: (String, Queue[Req]) => RIO[R, Nothing],
-    terminateMessage: Promise[Nothing, Unit] => Option[Req] = (_: Promise[Nothing, Unit]) => None
-  ): URIO[Scope with R, Unit] = registerRecipient(topicType, behavior, terminateMessage) *>
+    terminateMessage: Promise[Nothing, Unit] => Option[Req] = (_: Promise[Nothing, Unit]) => None,
+    loadEntity: Req => Boolean = (_: Req) => true
+  ): URIO[Scope with R, Unit] = registerRecipient(topicType, behavior, terminateMessage, None, loadEntity) *>
     eventsHub.publish(ShardingRegistrationEvent.TopicRegistered(topicType)).unit
 
   def getShardingRegistrationEvents: ZStream[Any, Nothing, ShardingRegistrationEvent] =
@@ -524,10 +527,19 @@ class Sharding private (
     recipientType: RecipientType[Req],
     behavior: (String, Queue[Req]) => RIO[R, Nothing],
     terminateMessage: Promise[Nothing, Unit] => Option[Req] = (_: Promise[Nothing, Unit]) => None,
-    entityMaxIdleTime: Option[Duration] = None
+    entityMaxIdleTime: Option[Duration],
+    loadEntity: Req => Boolean
   ): URIO[Scope with R, Unit] =
     for {
-      entityManager <- EntityManager.make(recipientType, behavior, terminateMessage, self, config, entityMaxIdleTime)
+      entityManager <- EntityManager.make(
+                         recipientType,
+                         behavior,
+                         terminateMessage,
+                         self,
+                         config,
+                         entityMaxIdleTime,
+                         loadEntity
+                       )
       processBinary  = (msg: BinaryMessage, replyChannel: ReplyChannel[Nothing]) =>
                          serialization
                            .decode[Req](msg.body)
@@ -648,27 +660,35 @@ object Sharding {
    * It takes a `behavior` which is a function from an entity ID and a queue of messages to a ZIO computation that runs forever and consumes those messages.
    * You can use `ZIO.interrupt` from the behavior to stop it (it will be restarted the next time the entity receives a message).
    * If provided, the optional `terminateMessage` will be sent to the entity before it is stopped, allowing for cleanup logic.
+   * If provided, `loadEntity` is a predicate that determines whether a new entity should be created for an incoming message.
+   * When it returns `false` and the entity doesn't already exist, the message is discarded. Defaults to always creating the entity.
    */
   def registerEntity[R, Req: Tag](
     entityType: EntityType[Req],
     behavior: (String, Queue[Req]) => RIO[R, Nothing],
     terminateMessage: Promise[Nothing, Unit] => Option[Req] = (_: Promise[Nothing, Unit]) => None,
-    entityMaxIdleTime: Option[Duration] = None
+    entityMaxIdleTime: Option[Duration] = None,
+    loadEntity: Req => Boolean = (_: Req) => true
   ): URIO[Sharding with Scope with R, Unit] =
-    ZIO.serviceWithZIO[Sharding](_.registerEntity[R, Req](entityType, behavior, terminateMessage, entityMaxIdleTime))
+    ZIO.serviceWithZIO[Sharding](
+      _.registerEntity[R, Req](entityType, behavior, terminateMessage, entityMaxIdleTime, loadEntity)
+    )
 
   /**
    * Register a new topic type, allowing pods to broadcast messages to subscribers.
    * It takes a `behavior` which is a function from a topic and a queue of messages to a ZIO computation that runs forever and consumes those messages.
    * You can use `ZIO.interrupt` from the behavior to stop it (it will be restarted the next time the topic receives a message).
    * If provided, the optional `terminateMessage` will be sent to the topic before it is stopped, allowing for cleanup logic.
+   * If provided, `loadEntity` is a predicate that determines whether a new entity should be created for an incoming message.
+   * When it returns `false` and the entity doesn't already exist, the message is discarded. Defaults to always creating the entity.
    */
   def registerTopic[R, Req: Tag](
     topicType: TopicType[Req],
     behavior: (String, Queue[Req]) => RIO[R, Nothing],
-    terminateMessage: Promise[Nothing, Unit] => Option[Req] = (_: Promise[Nothing, Unit]) => None
+    terminateMessage: Promise[Nothing, Unit] => Option[Req] = (_: Promise[Nothing, Unit]) => None,
+    loadEntity: Req => Boolean = (_: Req) => true
   ): URIO[Sharding with Scope with R, Unit] =
-    ZIO.serviceWithZIO[Sharding](_.registerTopic[R, Req](topicType, behavior, terminateMessage))
+    ZIO.serviceWithZIO[Sharding](_.registerTopic[R, Req](topicType, behavior, terminateMessage, loadEntity))
 
   /**
    * Get an object that allows sending messages to a given entity type.

--- a/entities/src/main/scala/com/devsisters/shardcake/internal/EntityManager.scala
+++ b/entities/src/main/scala/com/devsisters/shardcake/internal/EntityManager.scala
@@ -141,8 +141,9 @@ private[shardcake] object EntityManager {
       replyChannel: ReplyChannel[Nothing]
     ): IO[EntityNotManagedByThisPod, Unit] =
       currentTimeInMilliseconds.flatMap(cdt => entitiesLastReceivedAt.update(_ + (entityId -> cdt))) *>
+        // add the message to the queue and setup the reply channel if needed
         (replyId match {
-          case Some(replyId) => sharding.initReply(replyId, replyChannel) *> queue.offer(req).unit
+          case Some(replyId) => sharding.initReply(replyId, replyChannel) <* queue.offer(req)
           case None          => queue.offer(req) *> replyChannel.end
         }).catchAllCause(_ => Clock.sleep(100 millis) *> send(entityId, req, replyId, replyChannel))
 

--- a/entities/src/main/scala/com/devsisters/shardcake/internal/EntityManager.scala
+++ b/entities/src/main/scala/com/devsisters/shardcake/internal/EntityManager.scala
@@ -108,36 +108,43 @@ private[shardcake] object EntityManager {
     ): IO[EntityNotManagedByThisPod, Unit] =
       for {
         // first, verify that this entity should be handled by this pod
-        _     <- recipientType match {
-                   case _: EntityType[_] =>
-                     ZIO.unlessZIO(sharding.isEntityOnLocalShards(recipientType, entityId))(
-                       ZIO.fail(EntityNotManagedByThisPod(entityId))
-                     )
-                   case _: TopicType[_]  => ZIO.unit
-                 }
+        _   <- recipientType match {
+                 case _: EntityType[_] =>
+                   ZIO.unlessZIO(sharding.isEntityOnLocalShards(recipientType, entityId))(
+                     ZIO.fail(EntityNotManagedByThisPod(entityId))
+                   )
+                 case _: TopicType[_]  => ZIO.unit
+               }
         // find the queue for that entity, or create it if needed
-        map   <- entities.get
-        queue <- map.get(entityId) match {
-                   case Some(queue @ Left(_))    => ZIO.succeed(Some(queue))
-                   case None if !loadEntity(req) => ZIO.succeed(None)
-                   case _                        => getOrCreateQueue(entityId).asSome
-                 }
-        _     <- queue match {
-                   case None              =>
-                     // loadEntity returned false, do nothing
-                     replyChannel.end
-                   case Some(Right(_))    =>
-                     // the queue is shutting down, try again a little later
-                     Clock.sleep(100 millis) *> send(entityId, req, replyId, replyChannel)
-                   case Some(Left(queue)) =>
-                     currentTimeInMilliseconds.flatMap(cdt => entitiesLastReceivedAt.update(_ + (entityId -> cdt))) *>
-                       // add the message to the queue and setup the reply channel if needed
-                       (replyId match {
-                         case Some(replyId) => sharding.initReply(replyId, replyChannel) *> queue.offer(req)
-                         case None          => queue.offer(req) *> replyChannel.end
-                       }).catchAllCause(_ => Clock.sleep(100 millis) *> send(entityId, req, replyId, replyChannel))
-                 }
+        map <- entities.get
+        _   <- map.get(entityId) match {
+                 case Some(Left(queue))        =>
+                   offerToQueue(entityId, queue, req, replyId, replyChannel)
+                 case None if !loadEntity(req) =>
+                   replyChannel.end
+                 case _                        =>
+                   getOrCreateQueue(entityId).flatMap {
+                     case Right(_)    =>
+                       // the queue is shutting down, try again a little later
+                       Clock.sleep(100 millis) *> send(entityId, req, replyId, replyChannel)
+                     case Left(queue) =>
+                       offerToQueue(entityId, queue, req, replyId, replyChannel)
+                   }
+               }
       } yield ()
+
+    private def offerToQueue(
+      entityId: String,
+      queue: Queue[Req],
+      req: Req,
+      replyId: Option[String],
+      replyChannel: ReplyChannel[Nothing]
+    ): IO[EntityNotManagedByThisPod, Unit] =
+      currentTimeInMilliseconds.flatMap(cdt => entitiesLastReceivedAt.update(_ + (entityId -> cdt))) *>
+        (replyId match {
+          case Some(replyId) => sharding.initReply(replyId, replyChannel) *> queue.offer(req).unit
+          case None          => queue.offer(req) *> replyChannel.end
+        }).catchAllCause(_ => Clock.sleep(100 millis) *> send(entityId, req, replyId, replyChannel))
 
     private def getOrCreateQueue(entityId: String): IO[EntityNotManagedByThisPod, Either[Queue[Req], Signal]] =
       entities.modifyZIO(map =>

--- a/entities/src/main/scala/com/devsisters/shardcake/internal/EntityManager.scala
+++ b/entities/src/main/scala/com/devsisters/shardcake/internal/EntityManager.scala
@@ -27,7 +27,8 @@ private[shardcake] object EntityManager {
     terminateMessage: Signal => Option[Req],
     sharding: Sharding,
     config: Config,
-    entityMaxIdleTime: Option[Duration]
+    entityMaxIdleTime: Option[Duration],
+    loadEntity: Req => Boolean
   ): URIO[R, EntityManager[Req]] =
     for {
       entities               <- Ref.Synchronized.make[Map[String, Either[Queue[Req], Signal]]](Map())
@@ -41,7 +42,8 @@ private[shardcake] object EntityManager {
       entitiesLastReceivedAt,
       sharding,
       config,
-      entityMaxIdleTime
+      entityMaxIdleTime,
+      loadEntity
     )
 
   private val currentTimeInMilliseconds: UIO[EpochMillis] =
@@ -55,7 +57,8 @@ private[shardcake] object EntityManager {
     entitiesLastReceivedAt: Ref[Map[String, EpochMillis]],
     sharding: Sharding,
     config: Config,
-    entityMaxIdleTime: Option[Duration]
+    entityMaxIdleTime: Option[Duration],
+    loadEntity: Req => Boolean
   ) extends EntityManager[Req] {
     private val gauge = Metrics.entities.tagged("type", recipientType.name)
 
@@ -115,14 +118,18 @@ private[shardcake] object EntityManager {
         // find the queue for that entity, or create it if needed
         map   <- entities.get
         queue <- map.get(entityId) match {
-                   case Some(queue @ Left(_)) => ZIO.succeed(queue)
-                   case _                     => getOrCreateQueue(entityId)
+                   case Some(queue @ Left(_))    => ZIO.succeed(Some(queue))
+                   case None if !loadEntity(req) => ZIO.succeed(None)
+                   case _                        => getOrCreateQueue(entityId).asSome
                  }
         _     <- queue match {
-                   case Right(_)    =>
+                   case None              =>
+                     // loadEntity returned false, do nothing
+                     replyChannel.end
+                   case Some(Right(_))    =>
                      // the queue is shutting down, try again a little later
                      Clock.sleep(100 millis) *> send(entityId, req, replyId, replyChannel)
-                   case Left(queue) =>
+                   case Some(Left(queue)) =>
                      currentTimeInMilliseconds.flatMap(cdt => entitiesLastReceivedAt.update(_ + (entityId -> cdt))) *>
                        // add the message to the queue and setup the reply channel if needed
                        (replyId match {


### PR DESCRIPTION
This allows defining some messages that do not trigger the start of an entity, allowing "doing something only if the entity was already up" semantics.