### PR TITLE
Move grpc-netty dependency to Test scope

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -171,7 +171,7 @@ lazy val grpcProtocol = project
       "com.thesamet.scalapb"          %% "scalapb-runtime"      % scalapb.compiler.Version.scalapbVersion % "protobuf",
       "com.thesamet.scalapb"          %% "scalapb-runtime-grpc" % scalapb.compiler.Version.scalapbVersion,
       "com.thesamet.scalapb.zio-grpc" %% "zio-grpc-core"        % zioGrpcVersion,
-      "io.grpc"                        % "grpc-netty"           % grpcNettyVersion
+      "io.grpc"                        % "grpc-netty"           % grpcNettyVersion                        % Test
     )
   )
 
@@ -187,7 +187,7 @@ lazy val examples = project
         "dev.zio" %% "zio-streams" % zioVersion
       )
   )
-  .dependsOn(manager, storageRedis, grpcProtocol, serializationKryo)
+  .dependsOn(manager, storageRedis, grpcProtocol % "compile->compile;test->test", serializationKryo)
 
 lazy val benchmarks = project
   .in(file("benchmarks"))

--- a/build.sbt
+++ b/build.sbt
@@ -184,10 +184,11 @@ lazy val examples = project
     libraryDependencies ++=
       Seq(
         "dev.zio" %% "zio"         % zioVersion,
-        "dev.zio" %% "zio-streams" % zioVersion
+        "dev.zio" %% "zio-streams" % zioVersion,
+        "io.grpc"  % "grpc-netty"  % grpcNettyVersion
       )
   )
-  .dependsOn(manager, storageRedis, grpcProtocol % "compile->compile;test->test", serializationKryo)
+  .dependsOn(manager, storageRedis, grpcProtocol, serializationKryo)
 
 lazy val benchmarks = project
   .in(file("benchmarks"))


### PR DESCRIPTION
That will allow users of this library to choose gRPC transport to depend on, grpc-netty-shaded for example, without an exclusion rule.